### PR TITLE
Add citation and Swift Package index

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,4 +19,5 @@ authors:
   given-names: "Rao"
   orcid: "https://orcid.org/0000-0002-0780-033X"
 title: "SpeziSpeech"
+doi: 10.5281/zenodo.10146086
 url: "https://github.com/StanfordSpezi/SpeziSpeech"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ SPDX-License-Identifier: MIT
 
 [![Build and Test](https://github.com/StanfordSpezi/SpeziSpeech/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/StanfordSpezi/SpeziSpeech/actions/workflows/build-and-test.yml)
 [![codecov](https://codecov.io/gh/StanfordSpezi/SpeziSpeech/graph/badge.svg?token=ufmRQvE0Cs)](https://codecov.io/gh/StanfordSpezi/SpeziSpeech)
-
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10146086.svg)](https://doi.org/10.5281/zenodo.10146086)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziSpeech%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/StanfordSpezi/SpeziSpeech)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziSpeech%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/StanfordSpezi/SpeziSpeech)
 
 Recognize and synthesize natural language speech.
 


### PR DESCRIPTION
# Add citation and SPM index

## :recycle: Current situation & Problem
As we didn't tag a first release yet, the repo wasn't indexed by the Swift Package Index as well as Zendoo.


## :gear: Release Notes 
- Add citation and Swift Package index 


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
